### PR TITLE
Запуск inference.py в отдельном контейнере.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY ./.env /code/
 COPY ./src /code/src
 COPY ./inference.py /code/
 
-
-
+CMD ["poetry", "run", "uvicorn", "inference:app", "--host", "0.0.0.0", "--port", "8001"]
 
 

--- a/inference.py
+++ b/inference.py
@@ -10,7 +10,6 @@ MODEL_STAGE = "Staging"
 EXPERIMENT_NAME = "test_dvc_new"
 
 load_dotenv()
-os.environ["MLFLOW_S3_ENDPOINT_URL"] = os.getenv("MLFLOW_S3_ENDPOINT_URL")
 
 app = FastAPI()
 

--- a/test_inference.py
+++ b/test_inference.py
@@ -2,7 +2,7 @@ import http.client
 import os
 
 HOST = "localhost"
-PORT = 8000
+PORT = 8001
 METHOD = "POST"
 URL = "/invocations"
 TEST_FILE = "test_inference.csv"
@@ -23,7 +23,7 @@ headers = {
 
 # Формируем тело запроса с правильным форматом multipart/form-data
 body = (
-    b'--boundary\r\nContent-Disposition: form-data; name="file";'
+    b'--boundary\r\nContent-Disposition: form-data; name="file"; '
     b'filename="file.csv"\r\nContent-Type: application/octet-stream\r\n\r\n'
 )
 body += file_content


### PR DESCRIPTION
Команды
1. Создание образа: docker build -t fastapi_img .
2. Запуск контейнера: docker run -d --network docker_postgres --name fastapi_cnt -p 8001:8001 fastapi_img

Перед этим в .env прописать:
MLFLOW_TRACKING_URI=http://mlflow_server:5000